### PR TITLE
refactor: ajusta seletor do botão de configurações

### DIFF
--- a/content/index.js
+++ b/content/index.js
@@ -117,7 +117,13 @@
     // Injeta botão Kanban ao lado do botão de configurações
     (function injectKanbanButton() {
         const interval = setInterval(() => {
-            const settingsButton = document.querySelector('button[aria-label="Settings"]');
+
+            const settingsIcon = document.querySelectorAll('span[data-icon="settings-refreshed"]');
+            
+            if(settingsIcon.length === 0) return;
+            
+            const settingsButton = settingsIcon[0].closest("button");
+
             if (settingsButton && settingsButton.parentElement) {
                 clearInterval(interval);
 


### PR DESCRIPTION
Essa pequena PR altera a forma de localizar o ícone de configurações para posteriormente inserir o ícone do Kanban.

Ele utiliza o seletor do botão que tiver com o ícone de settings. Desta forma, independente do idioma vai funcionar. Antes, se não estivesse em inglês o ícone do Kanban não funcionava,

Muito legal esse projeto! Parabéns!